### PR TITLE
move bootloader entry to a tapdance

### DIFF
--- a/boards/shields/menura/menura.keymap
+++ b/boards/shields/menura/menura.keymap
@@ -16,13 +16,13 @@
         bootL: tap_dance_0 {
             compatible = "zmk,behavior-tap-dance";
             #binding-cells = <0>;
-            tapping-term-ms = <500>;
+            tapping-term-ms = <250>;
             bindings = <&kp Q>, <&kp Q>, <&bootloader>;
         };
         bootR: tap_dance_1 {
             compatible = "zmk,behavior-tap-dance";
             #binding-cells = <0>;
-            tapping-term-ms = <500>;
+            tapping-term-ms = <250>;
             bindings = <&kp P>, <&kp P>, <&bootloader>;
         };
     };

--- a/boards/shields/menura/menura.keymap
+++ b/boards/shields/menura/menura.keymap
@@ -16,13 +16,13 @@
         bootL: tap_dance_0 {
             compatible = "zmk,behavior-tap-dance";
             #binding-cells = <0>;
-            tapping-term-ms = <150>;
+            tapping-term-ms = <500>;
             bindings = <&kp Q>, <&kp Q>, <&bootloader>;
         };
         bootR: tap_dance_1 {
             compatible = "zmk,behavior-tap-dance";
             #binding-cells = <0>;
-            tapping-term-ms = <150>;
+            tapping-term-ms = <500>;
             bindings = <&kp P>, <&kp P>, <&bootloader>;
         };
     };

--- a/boards/shields/menura/menura.keymap
+++ b/boards/shields/menura/menura.keymap
@@ -5,20 +5,25 @@
 / {
     combos {
         compatible = "zmk,combos";
-        combo_bootloaderL {
-            timeout-ms = <50>;
-            key-positions = <0 4 10 14>;
-            bindings = <&bootloader>;
-        };
-        combo_bootloaderR {
-            timeout-ms = <50>;
-            key-positions = <5 9 15 19>;
-            bindings = <&bootloader>;
-        };
         combo_studio {
             timeout-ms = <50>;
             key-positions = <0 9 10 19>;
             bindings = <&studio_unlock>;
+        };
+    };
+
+    behaviors {
+        bootL: tap_dance_0 {
+            compatible = "zmk,behavior-tap-dance";
+            #binding-cells = <0>;
+            tapping-term-ms = <150>;
+            bindings = <&kp Q>, <&kp Q>, <&bootloader>;
+        };
+        bootR: tap_dance_1 {
+            compatible = "zmk,behavior-tap-dance";
+            #binding-cells = <0>;
+            tapping-term-ms = <150>;
+            bindings = <&kp P>, <&kp P>, <&bootloader>;
         };
     };
 };
@@ -29,10 +34,10 @@
 
         default_layer {
             bindings = <
-&kp Q &kp W &kp E &kp R &kp T   &kp Y &kp U &kp I &kp O &kp P
-&kp A &kp S &kp D &kp F &kp G   &kp H &kp J &kp K &kp L &kp SEMI
-&kp Z &kp X &kp C &kp V &kp B   &kp N &kp M &kp COMMA &kp DOT &kp FSLH
-         &kp N1 &kp N2 &kp N3   &kp N4 &kp N5 &kp N6
+&bootL &kp W &kp E &kp R &kp T   &kp Y &kp U &kp I &kp O &bootR
+&kp A  &kp S &kp D &kp F &kp G   &kp H &kp J &kp K &kp L &kp SEMI
+&kp Z  &kp X &kp C &kp V &kp B   &kp N &kp M &kp COMMA &kp DOT &kp FSLH
+          &kp N1 &kp N2 &kp N3   &kp N4 &kp N5 &kp N6
             >;
         };
 


### PR DESCRIPTION
Ref: https://discord.com/channels/719497620560543766/1287810089557950506/1287823213669126165

> You could put those in combos previously, and they'd always trigger on the central (this didn't change). This adds support for scenarios like:
> - Placing underglow toggles or ext power on combos (previously this'd only affect the central, not peripherals)
> - Same, but on encoders
> - Same, but on tap dances/mod-morphs/hold-taps/macros
> - Putting `&sys_reset`/`&bootloader` on tap dances/mod-morphs/hold-taps/macros (previously they'd always trigger on the central, not where the behavior is)

Previously, my bootloader entry on the peripheral side used a combo which didn't work as I expected -- it actually put the central device into bootloader. This is because combos always trigger the behavior on the central.  
Moving it to a tapdance lets it better respect locality, and put the appropriate half into bootloader, depending on the side where the behavior was activated from.

Keep an eye out on https://github.com/zmkfirmware/zmk/issues/2500 (ref: https://discord.com/channels/719497620560543766/813882537436905552/1324500848834904174) for combos potentially respecting locality in the future.